### PR TITLE
revamped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,7 +113,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.14",
  "proc-macro-hack",
 ]
 
@@ -229,6 +238,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "env_logger"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,7 +255,18 @@ checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -271,6 +301,7 @@ dependencies = [
  "dashmap",
  "once_cell",
  "parking_lot",
+ "quickcheck",
 ]
 
 [[package]]
@@ -451,12 +482,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -499,7 +559,10 @@ version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
+ "thread_local",
 ]
 
 [[package]]
@@ -627,6 +690,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +736,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +254,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.6.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fed24fd1e18827652b4d55652899a1e9da8e54d91624dc3437a5bc3a9f9a9c"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +318,7 @@ version = "0.2.0"
 dependencies = [
  "criterion",
  "dashmap",
+ "loom",
  "once_cell",
  "parking_lot",
  "quickcheck",
@@ -365,6 +385,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "loom"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44c73b4636e497b4917eb21c33539efa3816741a2d3ff26c6316f1b529481a4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generator",
+ "scoped-tls",
 ]
 
 [[package]]
@@ -590,6 +621,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +640,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,10 +10,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "bitflags"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bstr"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+
+[[package]]
+name = "byteorder"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+
+[[package]]
+name = "cast"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "bitflags",
+ "textwrap",
+ "unicode-width",
+]
 
 [[package]]
 name = "const-random"
@@ -36,15 +109,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools 0.10.0",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
+dependencies = [
+ "cast",
+ "itertools 0.9.0",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "dashmap"
 version = "3.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfcd41ae02d60edded204341d2798ba519c336c51a37330aa4b98a1128def32"
 dependencies = [
  "ahash",
- "cfg-if",
+ "cfg-if 0.1.10",
  "num_cpus",
 ]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "getrandom"
@@ -52,10 +234,16 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "half"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hermit-abi"
@@ -67,18 +255,110 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "intern-arc"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "dashmap",
  "once_cell",
+ "parking_lot",
 ]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "js-sys"
+version = "0.3.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
 version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+
+[[package]]
+name = "lock_api"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "memchr"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "memoffset"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_cpus"
@@ -97,13 +377,385 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07fffcddc1cb3a1de753caa4e4df03b79922ba43cf882acc1bdd7e8df9f4590"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38a02e23bd9604b842a812063aec4ef702b57989c37b655254bb61c471ad211"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "serde"
+version = "1.0.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43535db9747a4ba938c0ce0a98cc631a46ebf943c9e1d604e091df6007620bf6"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "syn"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2ada8616fad06a2d0c455adc530de4ef57605a8120cc65da9653e0e9623ca74"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
+
+[[package]]
+name = "web-sys"
+version = "0.3.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "intern-arc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,10 @@
 name = "intern-arc"
 description = "An interner that deallocates unused values"
 homepage = "https://github.com/Actyx/intern-arc"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Actyx AG <developer@actyx.io>"]
 edition = "2018"
-license = "Apache-2.0"
+license = "Apache-2.0 OR MIT"
 readme = "README.md"
 repository = "https://github.com/Actyx/intern-arc"
 keywords = ["intern", "interner", "interning"]
@@ -16,7 +16,6 @@ once_cell = "1.3"
 parking_lot = "0.11.1"
 
 [profile.bench]
-# setting to true may improve performance by 20% but more than doubles compile time
 lto = false
 debug = false # set to true when debugging sigsegv
 
@@ -29,4 +28,5 @@ criterion = "0.3.4"
 quickcheck = "1.0.3"
 
 [features]
+# turns on println debugging, useful when miri has found a problem
 println = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ parking_lot = "0.11.1"
 [profile.bench]
 # setting to true may improve performance by 20% but more than doubles compile time
 lto = false
+debug = false # set to true when debugging sigsegv
 
 [[bench]]
 name = "bench"
@@ -25,3 +26,7 @@ harness = false
 
 [dev-dependencies]
 criterion = "0.3.4"
+quickcheck = "1.0.3"
+
+[features]
+println = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,15 @@ keywords = ["intern", "interner", "interning"]
 [dependencies]
 dashmap = "3.11"
 once_cell = "1.3"
+parking_lot = "0.11.1"
+
+[profile.bench]
+# setting to true may improve performance by 20% but more than doubles compile time
+lto = false
+
+[[bench]]
+name = "bench"
+harness = false
+
+[dev-dependencies]
+criterion = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ harness = false
 
 [dev-dependencies]
 criterion = "0.3.4"
+loom = "0.4.0"
 quickcheck = "1.0.3"
 
 [features]

--- a/LICENSE-APACHE2.md
+++ b/LICENSE-APACHE2.md
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -175,3 +174,28 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT.md
+++ b/LICENSE-MIT.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Actyx AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,53 +1,10 @@
-# Library for interning based on stdlib Arc
+# Interning library based on atomic reference counting
 
-The design of the hash-based half is taken from the [`arc-interner`](https://docs.rs/arc-interner)
-crate, with the addition of another half based on [`BTreeMap`](https://doc.rust-lang.org/std/collections/struct.BTreeMap.html).
-Local benchmarks have shown that hashing is faster for objects below 1kB while tree traversal
-and comparisons are faster above 1kB (very roughly and broadly speaking).
+For the docs see [docs.rs](https://docs.rs/intern_arc).
 
-The main functions exist in three variants:
+When developing please make use of `cargo bench` and `cargo +nightly miri` — the multithreading tests are sized such that they bring issues to the surface when run with miri (which is rather slow).
+Once you notice problems, debugging is easier with
 
-  - `intern_hash` and friends for when you want to use hashing (or have no `Ord` instance at hand)
-  - `intern_tree` and friends for when you want to use tree map (or have no `Hash` instance at hand)
-  - `intern` and friends to automatically choose based on object size
-
-Within each of these classes, four function exist to ingest data in various forms:
-
-```rust
-use std::sync::Arc;
-use intern_arc::{intern, intern_unsized, intern_boxed, intern_arc};
-
-// for sized types
-let a1: Arc<String> = intern("hello".to_owned());
-
-// for unsized non-owned types
-let a2: Arc<str> = intern_unsized("hello");
-
-// for unsized owned types
-let a3: Arc<str> = intern_boxed(Box::<str>::from("hello"));
-
-// for types with shared ownership
-let a4: Arc<str> = intern_arc(Arc::<str>::from("hello"));
+```bash
+cargo +nightly miri test --features println -- --nocapture multithreading_hash
 ```
-
-# Introspection
-
-This library offers some utilities for checking how well it works for a given use-case:
-
-```rust
-use std::sync::Arc;
-use intern_arc::{inspect_hash, num_objects_interned_hash, types_interned};
-
-println!("str: {} objects", num_objects_interned_hash::<str>());
-
-let (hash, tree) = types_interned();
-println!("types interned: {} with hashing, {} with trees", hash, tree);
-
-inspect_hash::<[u8], _, _>(|iter| {
-    for arc in iter {
-        println!("{} x {:?}", Arc::strong_count(&arc), arc);
-    }
-});
-```
-
-All function exist also with `tree` suffix instead of `hash`.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ When developing please make use of `cargo bench` and `cargo +nightly miri` —
 Once you notice problems, debugging is easier with
 
 ```bash
+export MIRIFLAGS=-Zmiri-disable-isolation
 cargo +nightly miri test --features println -- --nocapture multithreading_hash
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ Once you notice problems, debugging is easier with
 ```bash
 cargo +nightly miri test --features println -- --nocapture multithreading_hash
 ```
+
+## License
+
+At your option: Apache-2.0 or MIT

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,95 @@
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use intern_arc::{Intern, Interned};
+
+fn intern_hello(interner: &Intern<str>) -> Interned<str> {
+    interner.intern_ref("hello")
+}
+
+fn intern_and_drop(interner: &Intern<str>) {
+    interner.intern_ref("hello");
+}
+
+fn hash(c: &mut Criterion) {
+    let mut c = c.benchmark_group("hash");
+    c.bench_function("intern fresh", |b| {
+        b.iter_batched_ref(
+            Intern::<str>::new,
+            |i| intern_hello(i),
+            BatchSize::SmallInput,
+        )
+    });
+    c.bench_function("intern known", |b| {
+        b.iter_batched_ref(
+            || {
+                let i = Intern::<str>::new();
+                i.intern_ref("hello");
+                i
+            },
+            |i| intern_hello(i),
+            BatchSize::SmallInput,
+        )
+    });
+    c.bench_function("intern & drop fresh", |b| {
+        b.iter_batched_ref(
+            Intern::<str>::new,
+            |i| intern_and_drop(i),
+            BatchSize::SmallInput,
+        )
+    });
+    c.bench_function("intern & drop known", |b| {
+        b.iter_batched_ref(
+            || {
+                let i = Intern::<str>::new();
+                i.intern_ref("hello");
+                i
+            },
+            |i| intern_and_drop(i),
+            BatchSize::SmallInput,
+        )
+    });
+    c.finish();
+}
+
+fn ord(c: &mut Criterion) {
+    let mut c = c.benchmark_group("ord");
+    c.bench_function("intern fresh", |b| {
+        b.iter_batched_ref(
+            || Intern::<str>::with_hash_limit(0),
+            |i| intern_hello(i),
+            BatchSize::SmallInput,
+        )
+    });
+    c.bench_function("intern known", |b| {
+        b.iter_batched_ref(
+            || {
+                let i = Intern::<str>::with_hash_limit(0);
+                i.intern_ref("hello");
+                i
+            },
+            |i| intern_hello(i),
+            BatchSize::SmallInput,
+        )
+    });
+    c.bench_function("intern & drop fresh", |b| {
+        b.iter_batched_ref(
+            || Intern::<str>::with_hash_limit(0),
+            |i| intern_and_drop(i),
+            BatchSize::SmallInput,
+        )
+    });
+    c.bench_function("intern & drop known", |b| {
+        b.iter_batched_ref(
+            || {
+                let i = Intern::<str>::with_hash_limit(0);
+                i.intern_ref("hello");
+                i
+            },
+            |i| intern_and_drop(i),
+            BatchSize::SmallInput,
+        )
+    });
+    c.finish();
+}
+
+criterion_group!(benches, hash, ord);
+criterion_main!(benches);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Actyx AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use intern_arc::{InternHash, InternOrd};
 use quickcheck::{Arbitrary, Gen};

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Actyx AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 use std::{
     hash::Hash,
     sync::{Arc, Weak},

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,0 +1,114 @@
+use std::{any::TypeId, fmt::Display, hash::Hash, ops::Deref, sync::Arc};
+
+use dashmap::DashMap;
+
+use crate::CONTAINER_HASH;
+
+struct HashContainer<T: ?Sized> {
+    hashed: DashMap<Arc<T>, ()>,
+}
+
+impl<T: Eq + Hash + ?Sized> HashContainer<T> {
+    pub fn new() -> Self {
+        HashContainer {
+            hashed: DashMap::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct InternedHash<T: ?Sized + Eq + Hash + 'static>(Arc<T>);
+
+impl<T: ?Sized + Eq + Hash + 'static> InternedHash<T> {
+    pub fn references(this: &Self) -> usize {
+        Arc::strong_count(&this.0)
+    }
+}
+
+impl<T: ?Sized + Eq + Hash + 'static + Display> Display for InternedHash<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<T: ?Sized + Eq + Hash + 'static> Deref for InternedHash<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl<T: ?Sized + Eq + Hash + 'static> Drop for InternedHash<T> {
+    fn drop(&mut self) {
+        // one reference from this Interned, one from the map
+        if Arc::strong_count(&self.0) == 2 {
+            if let Some(boxed) = CONTAINER_HASH
+                .get_or_init(DashMap::new)
+                .get(&TypeId::of::<T>())
+            {
+                let m = boxed.value().downcast_ref::<HashContainer<T>>().unwrap();
+                m.hashed
+                    .remove_if(&self.0, |k, _v| Arc::strong_count(k) == 2);
+            }
+        }
+    }
+}
+
+/// Intern a shared-ownership reference using hashing (will not clone)
+///
+/// Returns either the given Arc or an already-interned one pointing to an equivalent value.
+pub fn intern_hash_arc<T>(val: Arc<T>) -> InternedHash<T>
+where
+    T: Eq + Hash + Send + Sync + ?Sized + 'static,
+{
+    let type_map = CONTAINER_HASH.get_or_init(DashMap::new);
+
+    // Prefer taking the read lock to reduce contention, only use entry api if necessary.
+    let boxed = if let Some(boxed) = type_map.get(&TypeId::of::<T>()) {
+        boxed
+    } else {
+        type_map
+            .entry(TypeId::of::<T>())
+            .or_insert_with(|| Box::new(HashContainer::<T>::new()))
+            .downgrade()
+    };
+
+    let m: &HashContainer<T> = boxed.value().downcast_ref::<HashContainer<T>>().unwrap();
+    let b = m.hashed.entry(val).or_insert(());
+    let ret = b.key().clone();
+    drop(b);
+
+    InternedHash(ret)
+}
+
+/// Perform internal maintenance (removing otherwise unreferenced elements) and return count of elements
+pub fn num_objects_interned_hash<T: Eq + Hash + ?Sized + 'static>() -> usize {
+    if let Some(m) = CONTAINER_HASH
+        .get()
+        .and_then(|type_map| type_map.get(&TypeId::of::<T>()))
+    {
+        let m = m.downcast_ref::<HashContainer<T>>().unwrap();
+        m.hashed.len()
+    } else {
+        0
+    }
+}
+
+/// Feed an iterator over all interned values for the given type to the given function
+pub fn inspect_hash<T, F, U>(f: F) -> U
+where
+    T: Eq + Hash + ?Sized + 'static,
+    F: for<'a> FnOnce(Box<dyn Iterator<Item = Arc<T>> + 'a>) -> U,
+{
+    let o = CONTAINER_HASH
+        .get()
+        .and_then(|type_map| type_map.get(&TypeId::of::<T>()));
+    if let Some(r) = o {
+        let m = r.downcast_ref::<HashContainer<T>>().unwrap();
+        f(Box::new(m.hashed.iter().map(|r| r.key().clone())))
+    } else {
+        f(Box::new(std::iter::empty()))
+    }
+}

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,114 +1,108 @@
-use std::{any::TypeId, fmt::Display, hash::Hash, ops::Deref, sync::Arc};
+use std::{
+    hash::Hash,
+    sync::{Arc, Weak},
+};
 
 use dashmap::DashMap;
 
-use crate::CONTAINER_HASH;
+use crate::ref_count::{Interned, RemovalResult, RemovePtr};
 
-struct HashContainer<T: ?Sized> {
-    hashed: DashMap<Arc<T>, ()>,
+#[derive(Clone)]
+pub struct InternHash<T: ?Sized> {
+    inner: Arc<Inner<T>>,
 }
 
-impl<T: Eq + Hash + ?Sized> HashContainer<T> {
-    pub fn new() -> Self {
-        HashContainer {
-            hashed: DashMap::new(),
+#[repr(C)]
+struct Inner<T: ?Sized> {
+    remove_if_last: RemovePtr<T>,
+    map: DashMap<Interned<T>, ()>,
+}
+
+fn remove_if_last<T: ?Sized + Eq + Hash>(this: *const (), key: &Interned<T>) -> RemovalResult {
+    // this is safe because we’re still holding a weak reference: the value may be dropped
+    // but the ArcInner is still alive!
+    let weak = unsafe { Weak::from_raw(this as *const Inner<T>) };
+    let success = match weak.upgrade() {
+        Some(strong) => strong
+            .map
+            .remove_if(key, |k, _| k.ref_count() == 2)
+            .is_some(),
+        None => {
+            // This means that the last strong reference has started being dropped, so the map will be cleared.
+            // We drop the weak count because we won’t need to contact this interner anymore
+            drop(weak);
+            return RemovalResult::MapGone;
         }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(transparent)]
-pub struct InternedHash<T: ?Sized + Eq + Hash + 'static>(Arc<T>);
-
-impl<T: ?Sized + Eq + Hash + 'static> InternedHash<T> {
-    pub fn references(this: &Self) -> usize {
-        Arc::strong_count(&this.0)
-    }
-}
-
-impl<T: ?Sized + Eq + Hash + 'static + Display> Display for InternedHash<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl<T: ?Sized + Eq + Hash + 'static> Deref for InternedHash<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.deref()
-    }
-}
-
-impl<T: ?Sized + Eq + Hash + 'static> Drop for InternedHash<T> {
-    fn drop(&mut self) {
-        // one reference from this Interned, one from the map
-        if Arc::strong_count(&self.0) == 2 {
-            if let Some(boxed) = CONTAINER_HASH
-                .get_or_init(DashMap::new)
-                .get(&TypeId::of::<T>())
-            {
-                let m = boxed.value().downcast_ref::<HashContainer<T>>().unwrap();
-                m.hashed
-                    .remove_if(&self.0, |k, _v| Arc::strong_count(k) == 2);
-            }
-        }
-    }
-}
-
-/// Intern a shared-ownership reference using hashing (will not clone)
-///
-/// Returns either the given Arc or an already-interned one pointing to an equivalent value.
-pub fn intern_hash_arc<T>(val: Arc<T>) -> InternedHash<T>
-where
-    T: Eq + Hash + Send + Sync + ?Sized + 'static,
-{
-    let type_map = CONTAINER_HASH.get_or_init(DashMap::new);
-
-    // Prefer taking the read lock to reduce contention, only use entry api if necessary.
-    let boxed = if let Some(boxed) = type_map.get(&TypeId::of::<T>()) {
-        boxed
-    } else {
-        type_map
-            .entry(TypeId::of::<T>())
-            .or_insert_with(|| Box::new(HashContainer::<T>::new()))
-            .downgrade()
     };
-
-    let m: &HashContainer<T> = boxed.value().downcast_ref::<HashContainer<T>>().unwrap();
-    let b = m.hashed.entry(val).or_insert(());
-    let ret = b.key().clone();
-    drop(b);
-
-    InternedHash(ret)
-}
-
-/// Perform internal maintenance (removing otherwise unreferenced elements) and return count of elements
-pub fn num_objects_interned_hash<T: Eq + Hash + ?Sized + 'static>() -> usize {
-    if let Some(m) = CONTAINER_HASH
-        .get()
-        .and_then(|type_map| type_map.get(&TypeId::of::<T>()))
-    {
-        let m = m.downcast_ref::<HashContainer<T>>().unwrap();
-        m.hashed.len()
+    if success {
+        // need to decrement this Arc’s weak count — can’t be done by Interned::Drop since it cannot know this type
+        drop(weak);
+        RemovalResult::Removed
     } else {
-        0
+        // otherwise we need to keep the weak count because the caller will not drop the `this` pointer
+        // I prefer into_raw over forget because it clearly tells the Weak what is happening
+        Weak::into_raw(weak);
+        RemovalResult::NotRemoved
     }
 }
 
-/// Feed an iterator over all interned values for the given type to the given function
-pub fn inspect_hash<T, F, U>(f: F) -> U
-where
-    T: Eq + Hash + ?Sized + 'static,
-    F: for<'a> FnOnce(Box<dyn Iterator<Item = Arc<T>> + 'a>) -> U,
-{
-    let o = CONTAINER_HASH
-        .get()
-        .and_then(|type_map| type_map.get(&TypeId::of::<T>()));
-    if let Some(r) = o {
-        let m = r.downcast_ref::<HashContainer<T>>().unwrap();
-        f(Box::new(m.hashed.iter().map(|r| r.key().clone())))
-    } else {
-        f(Box::new(std::iter::empty()))
+impl<T: ?Sized + Eq + Hash> InternHash<T> {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                remove_if_last,
+                map: DashMap::new(),
+            }),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.map.is_empty()
+    }
+
+    fn intern(&self, interned: Interned<T>) -> Interned<T> {
+        let entry = self.inner.map.entry(interned).or_insert(());
+        let mut ret = entry.key().clone();
+        let me = Weak::into_raw(Arc::downgrade(&self.inner));
+        ret.make_hot(me as *mut RemovePtr<T>);
+        ret
+    }
+
+    pub fn intern_ref(&self, value: &T) -> Interned<T>
+    where
+        T: ToOwned,
+        T::Owned: Into<Box<T>>,
+    {
+        if let Some(entry) = self.inner.map.get(value) {
+            return entry.key().clone();
+        }
+        self.intern(Interned::from_box(value.to_owned().into()))
+    }
+
+    pub fn intern_box(&self, value: Box<T>) -> Interned<T> {
+        if let Some(entry) = self.inner.map.get(value.as_ref()) {
+            return entry.key().clone();
+        }
+        self.intern(Interned::from_box(value))
+    }
+
+    pub fn intern_sized(&self, value: T) -> Interned<T>
+    where
+        T: Sized,
+    {
+        if let Some(entry) = self.inner.map.get(&value) {
+            return entry.key().clone();
+        }
+        self.intern(Interned::from_sized(value))
+    }
+}
+
+impl<T: ?Sized + Eq + Hash> Default for InternHash<T> {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,38 @@
  * limitations under the License.
  */
 //! Interning library based on atomic reference counting
+//!
+//! This library differs from [`arc-interner`](https://crates.io/crates/arc-interner)
+//! (which served as initial inspiration) in that
+//!
+//!  - it contains no static global state (interners must be created and can be dropped;
+//!    you can use [`OnceCell`](https://docs.rs/once_cell) or [`lazy_static!`](https://docs.rs/lazy_static)
+//!    to manage global instances)
+//!  - it does not dispatch based on TypeId (each interner is for exactly one type)
+//!  - it offers both [`Hash`](https://doc.rust-lang.org/std/hash/trait.Hash.html)-based
+//!    and [`Ord`](https://doc.rust-lang.org/std/cmp/trait.Ord.html)-based storage
+//!  - it handles unsized types without overhead, so you should use `Intern<str>` instead of `Intern<String>`
+//!
+//! Unfortunately, this combination of features makes it inevitable to use unsafe Rust.
+//! The handling of reference counting and constructing of unsized values has been adapted
+//! from the standard library’s [`Arc`](https://doc.rust-lang.org/std/sync/struct.Arc.html) type.
+//! Additionally, the test suite passes also under [miri](https://github.com/rust-lang/miri) to
+//! check against some classes of undefined behavior in the unsafe code (including memory leaks).
+//!
+//! ## API flavors
+//!
+//! The same API is provided in two flavors:
+//!
+//!  - [`InternHash`](struct.InternHash.html) uses hash-based storage, namely a [`DashMap`](https://docs.rs/dashmap)
+//!  - [`InternOrd`](struct.InternOrd.html) uses ord-based storage, namely the standard
+//!    [`BTreeSet`](https://doc.rust-lang.org/std/collections/struct.BTreeSet.html)
+//!
+//! Interning small values takes of the order of 100–200ns on a typical server CPU. The ord-based
+//! storage has an advantage when interning large values (like slices greater than 1kB). The
+//! hash-based storage has an advantage when keeping lots of values (many thousands and up)
+//! interned at the same time.
+//!
+//! Nothing beats your own benchmarking, though.
 #![doc(html_logo_url = "https://developer.actyx.com/img/logo.svg")]
 #![doc(html_favicon_url = "https://developer.actyx.com/img/favicon.ico")]
 
@@ -24,312 +56,3 @@ mod tree;
 pub use hash::InternHash;
 pub use ref_count::Interned;
 pub use tree::InternOrd;
-
-use std::hash::Hash;
-
-pub struct Intern<T: ?Sized> {
-    hash_limit: usize,
-    hash: InternHash<T>,
-    ord: InternOrd<T>,
-}
-
-impl<T: ?Sized + Eq + Hash + Ord> Intern<T> {
-    pub fn new() -> Self {
-        Intern::default()
-    }
-
-    pub fn with_hash_limit(limit: usize) -> Self {
-        Self {
-            hash_limit: limit,
-            ..Default::default()
-        }
-    }
-
-    pub fn len(&self) -> usize {
-        self.hash.len() + self.ord.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.hash.is_empty() && self.ord.is_empty()
-    }
-
-    pub fn intern_ref(&self, value: &T) -> Interned<T>
-    where
-        T: ToOwned,
-        T::Owned: Into<Box<T>>,
-    {
-        if std::mem::size_of_val(value) > self.hash_limit {
-            self.ord.intern_ref(value)
-        } else {
-            self.hash.intern_ref(value)
-        }
-    }
-
-    pub fn intern_box(&self, value: Box<T>) -> Interned<T> {
-        if std::mem::size_of_val(value.as_ref()) > self.hash_limit {
-            self.ord.intern_box(value)
-        } else {
-            self.hash.intern_box(value)
-        }
-    }
-
-    pub fn intern_sized(&self, value: T) -> Interned<T>
-    where
-        T: Sized,
-    {
-        if std::mem::size_of_val(&value) > self.hash_limit {
-            self.ord.intern_sized(value)
-        } else {
-            self.hash.intern_sized(value)
-        }
-    }
-}
-
-impl<T: ?Sized + Eq + Hash + Ord> Default for Intern<T> {
-    fn default() -> Self {
-        Self {
-            hash_limit: 1000,
-            hash: Default::default(),
-            ord: Default::default(),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::*;
-    use std::thread;
-
-    // Test basic functionality.
-    #[test]
-    fn basic_hash() {
-        let interner = InternHash::<&str>::new();
-
-        assert_eq!(interner.intern_sized("foo"), interner.intern_sized("foo"));
-        assert_ne!(interner.intern_sized("foo"), interner.intern_sized("bar"));
-        // The above refs should be deallocated by now.
-        assert_eq!(interner.len(), 0);
-
-        let interner = InternHash::<String>::new();
-
-        let interned1 = interner.intern_sized("foo".to_string());
-        {
-            let interned2 = interner.intern_sized("foo".to_string());
-            let interned3 = interner.intern_sized("bar".to_string());
-
-            assert_eq!(interned2.ref_count(), 3);
-            assert_eq!(interned3.ref_count(), 2);
-            // We now have two unique interned strings: "foo" and "bar".
-            assert_eq!(interner.len(), 2);
-        }
-
-        // "bar" is now gone.
-        assert_eq!(interner.len(), 1);
-
-        drop(interner);
-        assert_eq!(interned1.ref_count(), 1);
-    }
-
-    // Test basic functionality.
-    #[test]
-    fn basic_hash_unsized() {
-        let interner = InternHash::<str>::new();
-
-        assert_eq!(interner.intern_ref("foo"), interner.intern_ref("foo"));
-        assert_ne!(interner.intern_ref("foo"), interner.intern_ref("bar"));
-        // The above refs should be deallocated by now.
-        assert_eq!(interner.len(), 0);
-
-        let interned1 = interner.intern_ref("foo");
-        {
-            let interned2 = interner.intern_ref("foo");
-            let interned3 = interner.intern_ref("bar");
-
-            assert_eq!(interned2.ref_count(), 3);
-            assert_eq!(interned3.ref_count(), 2);
-            // We now have two unique interned strings: "foo" and "bar".
-            assert_eq!(interner.len(), 2);
-        }
-
-        // "bar" is now gone.
-        assert_eq!(interner.len(), 1);
-
-        assert_eq!(
-            &*interned1 as *const _,
-            &*interner.intern_ref("foo") as *const _
-        );
-
-        drop(interner);
-
-        assert_ne!(
-            &*interned1 as *const _,
-            &*InternHash::new().intern_ref("foo") as *const _
-        );
-
-        assert_eq!(interned1.ref_count(), 1);
-    }
-
-    // Test basic functionality.
-    #[test]
-    fn basic_ord() {
-        let interner = InternOrd::<&str>::new();
-
-        assert_eq!(interner.intern_sized("foo"), interner.intern_sized("foo"));
-        assert_ne!(interner.intern_sized("foo"), interner.intern_sized("bar"));
-        // The above refs should be deallocated by now.
-        assert_eq!(interner.len(), 0);
-
-        let interner = InternOrd::<String>::new();
-
-        let interned1 = interner.intern_sized("foo".to_string());
-        {
-            let interned2 = interner.intern_sized("foo".to_string());
-            let interned3 = interner.intern_sized("bar".to_string());
-
-            assert_eq!(interned2.ref_count(), 3);
-            assert_eq!(interned3.ref_count(), 2);
-            // We now have two unique interned strings: "foo" and "bar".
-            assert_eq!(interner.len(), 2);
-        }
-
-        // "bar" is now gone.
-        assert_eq!(interner.len(), 1);
-
-        drop(interner);
-        assert_eq!(interned1.ref_count(), 1);
-    }
-
-    // Test basic functionality.
-    #[test]
-    fn basic_ord_unsized() {
-        let interner = InternOrd::<str>::new();
-
-        assert_eq!(interner.intern_ref("foo"), interner.intern_ref("foo"));
-        assert_ne!(interner.intern_ref("foo"), interner.intern_ref("bar"));
-        // The above refs should be deallocated by now.
-        assert_eq!(interner.len(), 0);
-
-        let interned1 = interner.intern_ref("foo");
-        {
-            let interned2 = interner.intern_ref("foo");
-            let interned3 = interner.intern_ref("bar");
-
-            assert_eq!(interned2.ref_count(), 3);
-            assert_eq!(interned3.ref_count(), 2);
-            // We now have two unique interned strings: "foo" and "bar".
-            assert_eq!(interner.len(), 2);
-        }
-
-        // "bar" is now gone.
-        assert_eq!(interner.len(), 1);
-
-        assert_eq!(
-            &*interned1 as *const _,
-            &*interner.intern_ref("foo") as *const _
-        );
-
-        drop(interner);
-
-        assert_ne!(
-            &*interned1 as *const _,
-            &*InternOrd::new().intern_ref("foo") as *const _
-        );
-
-        assert_eq!(interned1.ref_count(), 1);
-    }
-
-    // Ordering should be based on values, not pointers.
-    // Also tests `Display` implementation.
-    #[test]
-    fn sorting() {
-        let interner = InternHash::new();
-        let mut interned_vals = vec![
-            interner.intern_sized(4),
-            interner.intern_sized(2),
-            interner.intern_sized(5),
-            interner.intern_sized(0),
-            interner.intern_sized(1),
-            interner.intern_sized(3),
-        ];
-        interned_vals.sort();
-        let sorted: Vec<String> = interned_vals.iter().map(|v| format!("{}", v)).collect();
-        assert_eq!(&sorted.join(","), "0,1,2,3,4,5");
-    }
-
-    #[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
-    pub struct TestStruct(String, u64);
-
-    #[test]
-    fn sequential_hash() {
-        let interner = InternHash::new();
-
-        for _i in 0..1_000 {
-            let mut interned = Vec::with_capacity(100);
-            for j in 0..100 {
-                interned.push(interner.intern_sized(TestStruct("foo".to_string(), j)));
-            }
-        }
-
-        assert_eq!(interner.len(), 0);
-    }
-
-    #[test]
-    fn sequential_ord() {
-        let interner = InternOrd::new();
-
-        for _i in 0..1_000 {
-            let mut interned = Vec::with_capacity(100);
-            for j in 0..100 {
-                interned.push(interner.intern_sized(TestStruct("foo".to_string(), j)));
-            }
-        }
-
-        assert_eq!(interner.len(), 0);
-    }
-
-    // Quickly create and destroy a small number of interned objects from
-    // multiple threads.
-    #[test]
-    fn multithreading_hash() {
-        let interner = InternHash::new();
-
-        let mut thandles = vec![];
-        for _i in 0..10 {
-            let interner = interner.clone();
-            thandles.push(thread::spawn(move || {
-                for _i in 0..1_000 {
-                    let _interned1 = interner.intern_sized(TestStruct("foo".to_string(), 5));
-                    let _interned2 = interner.intern_sized(TestStruct("bar".to_string(), 10));
-                }
-            }));
-        }
-        for h in thandles.into_iter() {
-            h.join().unwrap()
-        }
-
-        assert_eq!(interner.len(), 0);
-    }
-
-    // Quickly create and destroy a small number of interned objects from
-    // multiple threads.
-    #[test]
-    fn multithreading_ord() {
-        let interner = InternOrd::new();
-
-        let mut thandles = vec![];
-        for _i in 0..10 {
-            let interner = interner.clone();
-            thandles.push(thread::spawn(move || {
-                for _i in 0..1_000 {
-                    let _interned1 = interner.intern_sized(TestStruct("foo".to_string(), 5));
-                    let _interned2 = interner.intern_sized(TestStruct("bar".to_string(), 10));
-                }
-            }));
-        }
-        for h in thandles.into_iter() {
-            h.join().unwrap()
-        }
-
-        assert_eq!(interner.len(), 0);
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,16 @@
 //! interned at the same time.
 //!
 //! Nothing beats your own benchmarking, though.
+//!
+//! ## Caveat emptor!
+//!
+//! This crate’s [`Interned`](struct.Interned.html) type does not optimise equality using
+//! pointer comparisons because there is a race condition between dropping a value and
+//! interning that same value that will lead to “orphaned” instances (meaning that
+//! interning that same value again later will yield a different storage location).
+//! All similarly constructed interning implementations share this caveat (e.g.
+//! [`internment`](https://crates.io/crates/internment) or the above mentioned
+//! [`arc-interner`](https://crates.io/crates/arc-interner)).
 #![doc(html_logo_url = "https://developer.actyx.com/img/logo.svg")]
 #![doc(html_favicon_url = "https://developer.actyx.com/img/favicon.ico")]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,19 +30,19 @@
 //!
 //! ```
 //! use std::sync::Arc;
-//! use intern_arc::{intern, intern_unsized, intern_boxed, intern_arc};
+//! use intern_arc::{intern, intern_unsized, intern_boxed, intern_arc, Interned};
 //!
 //! // for sized types
-//! let a1: Arc<String> = intern("hello".to_owned());
+//! let a1: Interned<String> = intern("hello".to_owned());
 //!
 //! // for unsized non-owned types
-//! let a2: Arc<str> = intern_unsized("hello");
+//! let a2: Interned<str> = intern_unsized("hello");
 //!
 //! // for unsized owned types
-//! let a3: Arc<str> = intern_boxed(Box::<str>::from("hello"));
+//! let a3: Interned<str> = intern_boxed(Box::<str>::from("hello"));
 //!
 //! // for types with shared ownership
-//! let a4: Arc<str> = intern_arc(Arc::<str>::from("hello"));
+//! let a4: Interned<str> = intern_arc(Arc::<str>::from("hello"));
 //! ```
 //!
 //! # Introspection
@@ -65,46 +65,57 @@
 //! });
 //! ```
 //!
-//! All function exist also with `tree` suffix instead of `hash`.
+//! All functions exist also with `tree` suffix instead of `hash`.
 #![doc(html_logo_url = "https://developer.actyx.com/img/logo.svg")]
 #![doc(html_favicon_url = "https://developer.actyx.com/img/favicon.ico")]
 
 use dashmap::DashMap;
 use once_cell::sync::OnceCell;
-use std::any::{Any, TypeId};
 use std::hash::Hash;
+use std::sync::Arc;
 use std::{
-    collections::{btree_map::Entry, BTreeMap},
-    sync::{
-        atomic::{AtomicIsize, Ordering},
-        Arc, Mutex,
-    },
+    any::{Any, TypeId},
+    fmt::Display,
+    ops::Deref,
 };
 
-struct HashContainer<T: ?Sized> {
-    hashed: DashMap<Arc<T>, ()>,
-    h_count: AtomicIsize,
+mod hash;
+mod tree;
+
+pub use hash::{inspect_hash, intern_hash_arc, num_objects_interned_hash, InternedHash};
+pub use tree::{inspect_tree, intern_tree_arc, num_objects_interned_tree, InternedTree};
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Interned<T: ?Sized + Eq + Hash + Ord + 'static> {
+    Hash(InternedHash<T>),
+    Tree(InternedTree<T>),
 }
 
-impl<T: Eq + Hash + ?Sized> HashContainer<T> {
-    pub fn new() -> Self {
-        HashContainer {
-            hashed: DashMap::new(),
-            h_count: AtomicIsize::new(1),
+impl<T: ?Sized + Eq + Hash + Ord + 'static> Interned<T> {
+    pub fn references(this: &Self) -> usize {
+        match this {
+            Interned::Hash(h) => InternedHash::references(h),
+            Interned::Tree(t) => InternedTree::references(t),
         }
     }
 }
 
-struct TreeContainer<T: ?Sized> {
-    tree: Mutex<BTreeMap<Arc<T>, ()>>,
-    t_count: AtomicIsize,
+impl<T: ?Sized + Eq + Hash + Ord + 'static + Display> Display for Interned<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Interned::Hash(h) => h.fmt(f),
+            Interned::Tree(t) => t.fmt(f),
+        }
+    }
 }
 
-impl<T: Ord + ?Sized> TreeContainer<T> {
-    pub fn new() -> Self {
-        TreeContainer {
-            tree: Mutex::new(BTreeMap::new()),
-            t_count: AtomicIsize::new(1),
+impl<T: ?Sized + Eq + Hash + Ord + 'static> Deref for Interned<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Interned::Hash(h) => h.deref(),
+            Interned::Tree(t) => t.deref(),
         }
     }
 }
@@ -112,40 +123,8 @@ impl<T: Ord + ?Sized> TreeContainer<T> {
 static CONTAINER_HASH: OnceCell<DashMap<TypeId, Box<dyn Any + Send + Sync>>> = OnceCell::new();
 static CONTAINER_TREE: OnceCell<DashMap<TypeId, Box<dyn Any + Send + Sync>>> = OnceCell::new();
 
-/// Intern a shared-ownership reference using hashing (will not clone)
-///
-/// Returns either the given Arc or an already-interned one pointing to an equivalent value.
-pub fn intern_hash_arc<T>(val: Arc<T>) -> Arc<T>
-where
-    T: Eq + Hash + Send + Sync + ?Sized + 'static,
-{
-    let type_map = CONTAINER_HASH.get_or_init(DashMap::new);
-
-    // Prefer taking the read lock to reduce contention, only use entry api if necessary.
-    let boxed = if let Some(boxed) = type_map.get(&TypeId::of::<T>()) {
-        boxed
-    } else {
-        type_map
-            .entry(TypeId::of::<T>())
-            .or_insert_with(|| Box::new(HashContainer::<T>::new()))
-            .downgrade()
-    };
-
-    let m: &HashContainer<T> = boxed.value().downcast_ref::<HashContainer<T>>().unwrap();
-    let b = m.hashed.entry(val).or_insert(());
-    let ret = b.key().clone();
-    drop(b);
-
-    // maintenance
-    if m.h_count.fetch_sub(1, Ordering::Relaxed) == 0 {
-        janitor_h(m);
-    }
-
-    ret
-}
-
 /// Intern an owned value using hashing (will not clone)
-pub fn intern_hash<T>(val: T) -> Arc<T>
+pub fn intern_hash<T>(val: T) -> InternedHash<T>
 where
     T: Eq + Hash + Send + Sync + 'static,
 {
@@ -153,7 +132,7 @@ where
 }
 
 /// Intern a non-owned reference using hashing (will clone)
-pub fn intern_hash_unsized<T>(val: &T) -> Arc<T>
+pub fn intern_hash_unsized<T>(val: &T) -> InternedHash<T>
 where
     T: Eq + Hash + Send + Sync + ?Sized + 'static,
     Arc<T>: for<'a> From<&'a T>,
@@ -162,53 +141,15 @@ where
 }
 
 /// Intern an owned reference using hashing (will not clone)
-pub fn intern_hash_boxed<T>(val: Box<T>) -> Arc<T>
+pub fn intern_hash_boxed<T>(val: Box<T>) -> InternedHash<T>
 where
     T: Eq + Hash + Send + Sync + ?Sized + 'static,
 {
     intern_hash_arc(Arc::from(val))
 }
 
-/// Intern a shared-ownership reference using tree map (will not clone)
-///
-/// Returns either the given Arc or an already-interned one pointing to an equivalent value.
-pub fn intern_tree_arc<T>(val: Arc<T>) -> Arc<T>
-where
-    T: Ord + Send + Sync + ?Sized + 'static,
-{
-    let type_map = CONTAINER_TREE.get_or_init(DashMap::new);
-
-    // Prefer taking the read lock to reduce contention, only use entry api if necessary.
-    let boxed = if let Some(boxed) = type_map.get(&TypeId::of::<T>()) {
-        boxed
-    } else {
-        type_map
-            .entry(TypeId::of::<T>())
-            .or_insert_with(|| Box::new(TreeContainer::<T>::new()))
-            .downgrade()
-    };
-
-    let m: &TreeContainer<T> = boxed.value().downcast_ref::<TreeContainer<T>>().unwrap();
-    let mut set = m.tree.lock().unwrap();
-    let ret = match set.entry(val) {
-        Entry::Vacant(x) => {
-            let ret = x.key().clone();
-            x.insert(());
-            ret
-        }
-        Entry::Occupied(x) => x.key().clone(),
-    };
-
-    // maintenance
-    if m.t_count.fetch_sub(1, Ordering::Relaxed) == 0 {
-        janitor_t(&mut *set, &m.t_count);
-    }
-
-    ret
-}
-
 /// Intern an owned value using tree map (will not clone)
-pub fn intern_tree<T>(val: T) -> Arc<T>
+pub fn intern_tree<T>(val: T) -> InternedTree<T>
 where
     T: Ord + Send + Sync + 'static,
 {
@@ -216,7 +157,7 @@ where
 }
 
 /// Intern a non-owned reference using tree map (will clone)
-pub fn intern_tree_unsized<T>(val: &T) -> Arc<T>
+pub fn intern_tree_unsized<T>(val: &T) -> InternedTree<T>
 where
     T: Ord + Send + Sync + ?Sized + 'static,
     Arc<T>: for<'a> From<&'a T>,
@@ -225,7 +166,7 @@ where
 }
 
 /// Intern an owned reference using tree map (will not clone)
-pub fn intern_tree_boxed<T>(val: Box<T>) -> Arc<T>
+pub fn intern_tree_boxed<T>(val: Box<T>) -> InternedTree<T>
 where
     T: Ord + Send + Sync + ?Sized + 'static,
 {
@@ -233,82 +174,53 @@ where
 }
 
 /// Intern an owned value (will not clone)
-pub fn intern<T>(val: T) -> Arc<T>
+pub fn intern<T>(val: T) -> Interned<T>
 where
     T: Eq + Hash + Ord + Send + Sync + 'static,
 {
     if std::mem::size_of::<T>() > 1000 {
-        intern_tree(val)
+        Interned::Tree(intern_tree(val))
     } else {
-        intern_hash(val)
+        Interned::Hash(intern_hash(val))
     }
 }
 
 /// Intern a non-owned reference (will clone)
-pub fn intern_unsized<T: ?Sized>(val: &T) -> Arc<T>
+pub fn intern_unsized<T: ?Sized>(val: &T) -> Interned<T>
 where
     T: Eq + Hash + Ord + Send + Sync + 'static,
     Arc<T>: for<'a> From<&'a T>,
 {
     if std::mem::size_of_val(val) > 1000 {
-        intern_tree_unsized(val)
+        Interned::Tree(intern_tree_unsized(val))
     } else {
-        intern_hash_unsized(val)
+        Interned::Hash(intern_hash_unsized(val))
     }
 }
 
 /// Intern an owned reference (will not clone)
-pub fn intern_boxed<T: ?Sized>(val: Box<T>) -> Arc<T>
+pub fn intern_boxed<T: ?Sized>(val: Box<T>) -> Interned<T>
 where
     T: Eq + Hash + Ord + Send + Sync + 'static,
 {
     if std::mem::size_of_val(val.as_ref()) > 1000 {
-        intern_tree_boxed(val)
+        Interned::Tree(intern_tree_boxed(val))
     } else {
-        intern_hash_boxed(val)
+        Interned::Hash(intern_hash_boxed(val))
     }
 }
 
 /// Intern a shared-ownership reference (will not clone)
 ///
 /// Returns either the given Arc or an already-interned one pointing to an equivalent value.
-pub fn intern_arc<T: ?Sized>(val: Arc<T>) -> Arc<T>
+pub fn intern_arc<T: ?Sized>(val: Arc<T>) -> Interned<T>
 where
     T: Eq + Hash + Ord + Send + Sync + 'static,
 {
     if std::mem::size_of_val(val.as_ref()) > 1000 {
-        intern_tree_arc(val)
+        Interned::Tree(intern_tree_arc(val))
     } else {
-        intern_hash_arc(val)
-    }
-}
-
-/// Perform internal maintenance (removing otherwise unreferenced elements) and return count of elements
-pub fn num_objects_interned_hash<T: Eq + Hash + ?Sized + 'static>() -> usize {
-    if let Some(m) = CONTAINER_HASH
-        .get()
-        .and_then(|type_map| type_map.get(&TypeId::of::<T>()))
-    {
-        let m = m.downcast_ref::<HashContainer<T>>().unwrap();
-        janitor_h(m);
-        m.hashed.len()
-    } else {
-        0
-    }
-}
-
-/// Perform internal maintenance (removing otherwise unreferenced elements) and return count of elements
-pub fn num_objects_interned_tree<T: Ord + ?Sized + 'static>() -> usize {
-    if let Some(m) = CONTAINER_TREE
-        .get()
-        .and_then(|type_map| type_map.get(&TypeId::of::<T>()))
-    {
-        let m = m.downcast_ref::<TreeContainer<T>>().unwrap();
-        let mut s = m.tree.lock().unwrap();
-        janitor_t(&mut *s, &m.t_count);
-        s.len()
-    } else {
-        0
+        Interned::Hash(intern_hash_arc(val))
     }
 }
 
@@ -318,76 +230,6 @@ pub fn types_interned() -> (usize, usize) {
         CONTAINER_HASH.get().map(|m| m.len()).unwrap_or_default(),
         CONTAINER_TREE.get().map(|m| m.len()).unwrap_or_default(),
     )
-}
-
-/// Feed an iterator over all interned values for the given type to the given function
-pub fn inspect_hash<T, F, U>(f: F) -> U
-where
-    T: Eq + Hash + ?Sized + 'static,
-    F: for<'a> FnOnce(Box<dyn Iterator<Item = Arc<T>> + 'a>) -> U,
-{
-    let o = CONTAINER_HASH
-        .get()
-        .and_then(|type_map| type_map.get(&TypeId::of::<T>()));
-    if let Some(r) = o {
-        let m = r.downcast_ref::<HashContainer<T>>().unwrap();
-        f(Box::new(m.hashed.iter().map(|r| r.key().clone())))
-    } else {
-        f(Box::new(std::iter::empty()))
-    }
-}
-
-/// Feed an iterator over all interned values for the given type to the given function
-pub fn inspect_tree<T, F, U>(f: F) -> U
-where
-    T: Ord + ?Sized + 'static,
-    F: for<'a> FnOnce(Box<dyn Iterator<Item = Arc<T>> + 'a>) -> U,
-{
-    let o = CONTAINER_TREE
-        .get()
-        .and_then(|type_map| type_map.get(&TypeId::of::<T>()));
-    if let Some(r) = o {
-        let m = r.downcast_ref::<TreeContainer<T>>().unwrap();
-        let map = m.tree.lock().unwrap();
-        f(Box::new(map.iter().map(|(k, _v)| k.clone())))
-    } else {
-        f(Box::new(std::iter::empty()))
-    }
-}
-
-fn janitor_h<T: Eq + Hash + ?Sized + 'static>(m: &HashContainer<T>) {
-    let before = m.hashed.len();
-    m.hashed.retain(|k, _v| Arc::strong_count(k) > 1);
-    let after = m.hashed.len();
-    let removed = (before as isize - after as isize).max(1) as usize;
-    // assume removals are always possible
-    // the interval is tuned such that it is very short for high churn and very long for low churn
-    // this is done such that the amortized cost is one retain check per insert
-    m.h_count
-        .store((before / removed) as isize, Ordering::Relaxed);
-}
-
-fn janitor_t<T: Ord + ?Sized + 'static>(set: &mut BTreeMap<Arc<T>, ()>, count: &AtomicIsize) {
-    let before = set.len();
-    let to_remove = set
-        .iter()
-        .filter_map(|(k, _v)| {
-            if Arc::strong_count(k) == 1 {
-                Some(k.clone())
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<_>>();
-    for a in to_remove {
-        set.remove(&a);
-    }
-    let after = set.len();
-    let removed = (before - after).max(1);
-    // assume removals are always possible
-    // the interval is tuned such that it is very short for high churn and very long for low churn
-    // this is done such that the amortized cost is one retain check per insert
-    count.store((before / removed) as isize, Ordering::Relaxed);
 }
 
 #[cfg(test)]
@@ -400,7 +242,7 @@ mod tests {
     fn basic_hash() {
         assert_eq!(intern_hash("foo"), intern_hash("foo"));
         assert_ne!(intern_hash("foo"), intern_hash("bar"));
-        // The above refs should be deallocate by now.
+        // The above refs should be deallocated by now.
         assert_eq!(num_objects_interned_hash::<&str>(), 0);
 
         let _interned1 = intern_hash("foo".to_string());
@@ -408,8 +250,8 @@ mod tests {
             let interned2 = intern_hash("foo".to_string());
             let interned3 = intern_hash("bar".to_string());
 
-            assert_eq!(Arc::strong_count(&interned2), 3);
-            assert_eq!(Arc::strong_count(&interned3), 2);
+            assert_eq!(InternedHash::references(&interned2), 3);
+            assert_eq!(InternedHash::references(&interned3), 2);
             // We now have two unique interned strings: "foo" and "bar".
             assert_eq!(num_objects_interned_hash::<String>(), 2);
         }
@@ -423,7 +265,7 @@ mod tests {
     fn basic_hash_unsized() {
         assert_eq!(intern_hash_unsized("foo"), intern_hash_unsized("foo"));
         assert_ne!(intern_hash_unsized("foo"), intern_hash_unsized("bar"));
-        // The above refs should be deallocate by now.
+        // The above refs should be deallocated by now.
         assert_eq!(num_objects_interned_hash::<str>(), 0);
 
         let _interned1 = intern_hash_unsized("foo");
@@ -431,8 +273,8 @@ mod tests {
             let interned2 = intern_hash_unsized("foo");
             let interned3 = intern_hash_unsized("bar");
 
-            assert_eq!(Arc::strong_count(&interned2), 3);
-            assert_eq!(Arc::strong_count(&interned3), 2);
+            assert_eq!(InternedHash::references(&interned2), 3);
+            assert_eq!(InternedHash::references(&interned3), 2);
             // We now have two unique interned strings: "foo" and "bar".
             assert_eq!(num_objects_interned_hash::<str>(), 2);
         }
@@ -446,7 +288,7 @@ mod tests {
     fn basic_tree() {
         assert_eq!(intern_tree("foo"), intern_tree("foo"));
         assert_ne!(intern_tree("foo"), intern_tree("bar"));
-        // The above refs should be deallocate by now.
+        // The above refs should be deallocated by now.
         assert_eq!(num_objects_interned_tree::<&str>(), 0);
 
         let _interned1 = intern_tree("foo".to_string());
@@ -454,8 +296,8 @@ mod tests {
             let interned2 = intern_tree("foo".to_string());
             let interned3 = intern_tree("bar".to_string());
 
-            assert_eq!(Arc::strong_count(&interned2), 3);
-            assert_eq!(Arc::strong_count(&interned3), 2);
+            assert_eq!(InternedTree::references(&interned2), 3);
+            assert_eq!(InternedTree::references(&interned3), 2);
             // We now have two unique interned strings: "foo" and "bar".
             assert_eq!(num_objects_interned_tree::<String>(), 2);
         }
@@ -469,7 +311,7 @@ mod tests {
     fn basic_tree_unsized() {
         assert_eq!(intern_tree_unsized("foo"), intern_tree_unsized("foo"));
         assert_ne!(intern_tree_unsized("foo"), intern_tree_unsized("bar"));
-        // The above refs should be deallocate by now.
+        // The above refs should be deallocated by now.
         assert_eq!(num_objects_interned_tree::<str>(), 0);
 
         let _interned1 = intern_tree_unsized("foo");
@@ -477,8 +319,8 @@ mod tests {
             let interned2 = intern_tree_unsized("foo");
             let interned3 = intern_tree_unsized("bar");
 
-            assert_eq!(Arc::strong_count(&interned2), 3);
-            assert_eq!(Arc::strong_count(&interned3), 2);
+            assert_eq!(InternedTree::references(&interned2), 3);
+            assert_eq!(InternedTree::references(&interned3), 2);
             // We now have two unique interned strings: "foo" and "bar".
             assert_eq!(num_objects_interned_tree::<str>(), 2);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Actyx AG
+ * Copyright 2021 Actyx AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,7 @@
+use std::{slice::from_raw_parts, sync::Arc};
+
+fn main() {
+    let x: Arc<str> = "hello".into();
+    let s = unsafe { from_raw_parts(&x as *const _ as *const u8, 16) };
+    println!("{:?}", s);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,0 @@
-use std::{slice::from_raw_parts, sync::Arc};
-
-fn main() {
-    let x: Arc<str> = "hello".into();
-    let s = unsafe { from_raw_parts(&x as *const _ as *const u8, 16) };
-    println!("{:?}", s);
-}

--- a/src/ref_count.rs
+++ b/src/ref_count.rs
@@ -1,7 +1,7 @@
 use std::{
     alloc::{alloc, dealloc, Layout},
     borrow::Borrow,
-    fmt::{Debug, Display, Formatter, Result},
+    fmt::{Debug, Display, Formatter, Pointer, Result},
     hash::{Hash, Hasher},
     intrinsics::drop_in_place,
     ops::Deref,
@@ -59,14 +59,18 @@ impl<T: ?Sized> RefCounted<T> {
             // write the fields
             (*ptr).refs = AtomicUsize::new(1);
             (*ptr).remove_if_last = AtomicPtr::new(std::ptr::null_mut());
-            std::ptr::copy_nonoverlapping(
-                // copy payload value byte-wise, because what else can we do?
-                b as *const u8,
-                &mut (*ptr).value as *mut _ as *mut u8,
-                std::mem::size_of_val(&*b),
-            );
-            // free the memory of the ex-Box
-            dealloc(b as *mut u8, Layout::for_value(&*b));
+            let num_bytes = std::mem::size_of_val(&*b);
+            if num_bytes > 0 {
+                std::ptr::copy_nonoverlapping(
+                    // copy payload value byte-wise, because what else can we do?
+                    b as *const u8,
+                    &mut (*ptr).value as *mut _ as *mut u8,
+                    num_bytes,
+                );
+                // free the memory of the ex-Box; global allocator does not allow zero-sized allocations
+                // so this must be guarded by num_bytes > 0
+                dealloc(b as *mut u8, Layout::for_value(&*b));
+            }
 
             NonNull::new_unchecked(ptr)
         }
@@ -92,8 +96,22 @@ pub struct Interned<T: ?Sized> {
 unsafe impl<T: ?Sized + Sync + Send> Send for Interned<T> {}
 unsafe impl<T: ?Sized + Sync + Send> Sync for Interned<T> {}
 
+/// An interned value
+///
+/// This type works very similar to an [`Arc`](https://doc.rust-lang.org/std/sync/struct.Arc.html)
+/// with the difference that it has no concept of weak references. They are not needed because
+/// **interned values must not be modified**, so reference cycles cannot be constructed. One
+/// reference is held by the interner that created this value as long as that interner lives.
+///
+/// Keeping interned values around does not keep the interner alive: once the last reference to
+/// the interner is dropped, it will release its existing interned values, so the backing memory
+/// will be released once each of the interned values is no longer referenced through any `Interned`
+/// instances. (`Interned` keeps a [`Weak`](https://doc.rust-lang.org/std/sync/struct.Weak.html)
+/// reference to the interner that created it, so it will prevent the `ArcInner` from being
+/// deallocated while it lives.)
 impl<T: ?Sized> Interned<T> {
-    /// Obtain current number of references, including this one, using Ordering::Relaxed.
+    /// Obtain current number of references, including this one, using
+    /// [`Ordering::Relaxed`](https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html#variant.Relaxed).
     /// This means that reads and writes of your code may be freely reordered around this
     /// read, there is no synchronisation with other threads.
     ///
@@ -139,12 +157,17 @@ impl<T: ?Sized> Clone for Interned<T> {
             // the below misspelling is deliberate
             panic!("either you are running on an 8086 or you are leaking Interned values at a phantastic rate");
         }
-        Self { inner: self.inner }
+        let ret = Self { inner: self.inner };
+        #[cfg(feature = "println")]
+        println!("clone {:p} {:p}", self, ret);
+        ret
     }
 }
 
 impl<T: ?Sized> Drop for Interned<T> {
     fn drop(&mut self) {
+        #[cfg(feature = "println")]
+        println!("dropping {:p}", self);
         // precondition:
         //  - this Interned may or may not be referenced by an interner (since the interner can be dropped)
         //  - the `self` reference guarantees that the reference count is at least one
@@ -165,17 +188,18 @@ impl<T: ?Sized> Drop for Interned<T> {
                 //    (race conditions against drop & clone, latter allows further usage and dropping)
                 // 3. this map reference plus external: successful remove_if_last or interner is being dropped
                 //    (race conditions against drop & clone)
-                let remove_ptr = self
-                    .inner()
-                    .remove_if_last
-                    .swap(std::ptr::null_mut(), Release);
-                if remove_ptr.is_null() {
+                const TAKEN: *mut u8 = std::mem::align_of::<RemovePtr<()>>() as *mut _;
+                // must not set to null here: spurious `get` failure in DashMap may lead to another make_hot
+                let remove_ptr = self.inner().remove_if_last.swap(TAKEN as *mut _, AcqRel);
+                if remove_ptr as *mut u8 == TAKEN {
                     // happens in scenario 2, in which case this has turned into a normal Arc.
                     // (here it might be that the function pointer is still held by the other concurrent dropper,
                     // but that one will put it back and retry)
                     // happens in scenario 1 during successful remove_if_last.
                     // happens in scenario 1 while dropping the interner.
                     // does not happen during interning race because there ref count is 1
+                    #[cfg(feature = "println")]
+                    println!("null {:p}", self);
                     break;
                 } else {
                     // we got a valid pointer because our weak reference is still in place
@@ -189,6 +213,8 @@ impl<T: ?Sized> Drop for Interned<T> {
                             // scenario 1 confirmed and races won:
                             // weak reference on interner has been dropped, so has our ref_count
                             // so the code below will now drop this value
+                            #[cfg(feature = "println")]
+                            println!("removed {:p}", self);
                             break;
                         }
                         RemovalResult::NotRemoved => {
@@ -200,11 +226,15 @@ impl<T: ?Sized> Drop for Interned<T> {
                             // have been dropped or interner dropped), so we must check again: seeing 3 means that
                             // someone else will successfully use the pointer in the future, seeing 1 means that
                             // the situation has been cleared up permanently, seeing 2 we need to try again
+                            #[cfg(feature = "println")]
+                            println!("loop {:p}", self);
                         }
                         RemovalResult::MapGone => {
                             // scenario 2 or scenario 1 with concurrent drop of interner
                             // the interner has begun dropping at some point in the past, so its reference to
                             // us is either gone or will be gone soon; in any case our weak reference to it is toast
+                            #[cfg(feature = "println")]
+                            println!("gone{:p}", self);
                             break;
                         }
                     }
@@ -219,8 +249,12 @@ impl<T: ?Sized> Drop for Interned<T> {
         // Acquire ordering is needed to synchronise with a possible Release on remove_if_last.
         let prior_refs = self.inner().refs.fetch_sub(1, Release);
         if prior_refs != 1 {
+            #[cfg(feature = "println")]
+            println!("no drop {:p}", self);
             return;
         }
+        #[cfg(feature = "println")]
+        println!("drop {:p}", self);
 
         // Final reference, do delete! We need to ensure that the previous drop on a different
         // thread has stopped using the data (i.e. synchronise with the Release above).
@@ -281,6 +315,12 @@ impl<T: ?Sized> Deref for Interned<T> {
     }
 }
 
+impl<T: ?Sized> AsRef<T> for Interned<T> {
+    fn as_ref(&self) -> &T {
+        self.deref()
+    }
+}
+
 impl<T: ?Sized + Debug> Debug for Interned<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "Interned({:?})", &*self)
@@ -290,5 +330,11 @@ impl<T: ?Sized + Debug> Debug for Interned<T> {
 impl<T: ?Sized + Display> Display for Interned<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         self.deref().fmt(f)
+    }
+}
+
+impl<T: ?Sized> Pointer for Interned<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        Pointer::fmt(&(&**self as *const T), f)
     }
 }

--- a/src/ref_count.rs
+++ b/src/ref_count.rs
@@ -1,0 +1,285 @@
+use std::{
+    alloc::{alloc, dealloc, Layout},
+    borrow::Borrow,
+    fmt::{Debug, Formatter, Result},
+    hash::{Hash, Hasher},
+    intrinsics::drop_in_place,
+    ops::Deref,
+    ptr::NonNull,
+    sync::atomic::{AtomicPtr, AtomicUsize, Ordering::*},
+};
+
+pub(crate) type RemovePtr<T> = fn(*const (), &Interned<T>) -> RemovalResult;
+pub(crate) enum RemovalResult {
+    /// weak reference has been dropped
+    Removed,
+    /// weak reference has NOT been dropped
+    NotRemoved,
+    /// weak reference has been dropped
+    MapGone,
+}
+
+#[repr(C)]
+struct RefCounted<T: ?Sized> {
+    /// number of references held to this value, including the one from the interner map
+    refs: AtomicUsize,
+    /// Pointer to the location of a function pointer that can remove a given
+    /// Interned<T> from the interner map. This same pointer is also provided
+    /// as the first argument to the remove_if_last function in order to find
+    /// the interner state in memory, so use #[repr(C)] and put the function
+    /// pointer first!
+    ///
+    /// The function must remove the value from the interner if the reference
+    /// count is TWO (one for the map, one for the last external reference).
+    remove_if_last: AtomicPtr<RemovePtr<T>>,
+    value: T,
+}
+
+impl<T: ?Sized> RefCounted<T> {
+    fn from_box(value: Box<T>) -> NonNull<Self> {
+        // figure out the needed allocation size — this requires #[repr(C)]
+        let layout = Layout::new::<RefCounted<()>>()
+            .extend(Layout::for_value(value.as_ref()))
+            .unwrap() // fails only on address range overflow
+            .0
+            .pad_to_align();
+        unsafe {
+            // allocate using global allocator
+            let ptr = alloc(layout);
+            // get value pointer with the right metadata (e.g. string length)
+            // while making sure to NOT DROP THE BOX
+            let b = Box::leak(value) as *mut T;
+            // construct correct (fat) pointer from allocation result
+            let ptr = {
+                let mut temp = b as *mut Self;
+                // unfortunately <*const>::set_ptr_value is still experimental, but this is what it does:
+                std::ptr::write(&mut temp as *mut _ as *mut *mut u8, ptr);
+                temp
+            };
+            // write the fields
+            (*ptr).refs = AtomicUsize::new(1);
+            (*ptr).remove_if_last = AtomicPtr::new(std::ptr::null_mut());
+            std::ptr::copy_nonoverlapping(
+                // copy payload value byte-wise, because what else can we do?
+                b as *const u8,
+                &mut (*ptr).value as *mut _ as *mut u8,
+                std::mem::size_of_val(&*b),
+            );
+            // free the memory of the ex-Box
+            dealloc(b as *mut u8, Layout::for_value(&*b));
+
+            NonNull::new_unchecked(ptr)
+        }
+    }
+
+    fn from_sized(value: T) -> NonNull<Self>
+    where
+        T: Sized,
+    {
+        let b = Box::new(Self {
+            refs: AtomicUsize::new(1),
+            remove_if_last: AtomicPtr::new(std::ptr::null_mut()),
+            value,
+        });
+        NonNull::from(Box::leak(b))
+    }
+}
+
+pub struct Interned<T: ?Sized> {
+    inner: NonNull<RefCounted<T>>,
+}
+
+impl<T: ?Sized> Interned<T> {
+    /// Obtain current number of references, including this one, using Ordering::Relaxed.
+    /// This means that reads and writes of your code may be freely reordered around this
+    /// read, there is no synchronisation with other threads.
+    ///
+    /// The value will always be at least 1. If the value is 1, this means that the interner
+    /// which produced this reference has been dropped; in this case you are still free to
+    /// use this reference in any way you like.
+    pub fn ref_count(&self) -> usize {
+        self.inner().refs.load(Relaxed)
+    }
+
+    fn inner(&self) -> &RefCounted<T> {
+        // this is safe since the existence of &self proves that the pointer is still valid
+        unsafe { self.inner.as_ref() }
+    }
+
+    pub(crate) fn from_box(value: Box<T>) -> Self {
+        Self {
+            inner: RefCounted::from_box(value),
+        }
+    }
+
+    pub(crate) fn from_sized(value: T) -> Self
+    where
+        T: Sized,
+    {
+        Self {
+            inner: RefCounted::from_sized(value),
+        }
+    }
+
+    pub(crate) fn make_hot(&mut self, map: *mut RemovePtr<T>) -> bool {
+        self.inner()
+            .remove_if_last
+            .compare_exchange(std::ptr::null_mut(), map, Relaxed, Relaxed)
+            .is_ok()
+    }
+}
+
+impl<T: ?Sized> Clone for Interned<T> {
+    fn clone(&self) -> Self {
+        const MAX_REFCOUNT: usize = usize::MAX - 1;
+        if self.inner().refs.fetch_add(1, Relaxed) == MAX_REFCOUNT {
+            // the below misspelling is deliberate
+            panic!("either you are running on an 8086 or you are leaking Interned values at a phantastic rate");
+        }
+        Self { inner: self.inner }
+    }
+}
+
+impl<T: ?Sized> Drop for Interned<T> {
+    fn drop(&mut self) {
+        // precondition:
+        //  - this Interned may or may not be referenced by an interner (since the interner can be dropped)
+        //  - the `self` reference guarantees that the reference count is at least one
+        //  - whatever happens, we must decrement the reference count by one
+        //  - if the only remaining reference is the interner map, we need to try to remove it
+        //    (this races against an `intern` call for the same value)
+        //
+        // IMPORTANT NOTE: each Interned starts out with two references!
+
+        // after decrementing the reference count, we must consider our memory to be freed
+        // by another thread (impossible when prior_refs == 1), so all work must happen before
+        loop {
+            if self.inner().refs.load(Relaxed) == 2 {
+                // three scenarios:
+                // 1. this external reference plus the map
+                //    (only race condition is against interning of same value or drop of interner)
+                // 2. this external reference plus another external
+                //    (race conditions against drop & clone, latter allows further usage and dropping)
+                // 3. this map reference plus external: successful remove_if_last or interner is being dropped
+                //    (race conditions against drop & clone)
+                let remove_ptr = self
+                    .inner()
+                    .remove_if_last
+                    .swap(std::ptr::null_mut(), Release);
+                if remove_ptr.is_null() {
+                    // happens in scenario 2, in which case this has turned into a normal Arc.
+                    // (here it might be that the function pointer is still held by the other concurrent dropper,
+                    // but that one will put it back and retry)
+                    // happens in scenario 1 during successful remove_if_last.
+                    // happens in scenario 1 while dropping the interner.
+                    // does not happen during interning race because there ref count is 1
+                    break;
+                } else {
+                    // we got a valid pointer because our weak reference is still in place
+                    //
+                    // THIS FUNCTION POINTER MUST BE USED SUCCESSFULLY EXACTLY ONCE!
+                    //
+                    let raw_arc = remove_ptr as *const ();
+                    let remove_if_last = unsafe { *remove_ptr };
+                    match remove_if_last(raw_arc, self) {
+                        RemovalResult::Removed => {
+                            // scenario 1 confirmed and races won:
+                            // weak reference on interner has been dropped, so has our ref_count
+                            // so the code below will now drop this value
+                            break;
+                        }
+                        RemovalResult::NotRemoved => {
+                            // scenario 1 confirmed and race lost:
+                            // another thread has won the race and obtained a fresh reference, so we
+                            // keep our weak reference and put back the removal function pointer
+                            self.inner().remove_if_last.store(remove_ptr, Release);
+                            // at this point it is unclear what else has happened (other reference could already
+                            // have been dropped or interner dropped), so we must check again: seeing 3 means that
+                            // someone else will successfully use the pointer in the future, seeing 1 means that
+                            // the situation has been cleared up permanently, seeing 2 we need to try again
+                        }
+                        RemovalResult::MapGone => {
+                            // scenario 2 or scenario 1 with concurrent drop of interner
+                            // the interner has begun dropping at some point in the past, so its reference to
+                            // us is either gone or will be gone soon; in any case our weak reference to it is toast
+                            break;
+                        }
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+
+        // Release ordering is needed to be able to synchronise with the Acquire before actually dropping the value
+        // to ensure that there cannot be any pending writes to the allocation.
+        // Acquire ordering is needed to synchronise with a possible Release on remove_if_last.
+        let prior_refs = self.inner().refs.fetch_sub(1, Release);
+        if prior_refs != 1 {
+            return;
+        }
+
+        // Final reference, do delete! We need to ensure that the previous drop on a different
+        // thread has stopped using the data (i.e. synchronise with the Release above).
+        assert!(self.inner().refs.load(Acquire) == 0);
+
+        let layout = Layout::for_value(self.inner());
+        unsafe {
+            // this is how you drop unsized values ...
+            drop_in_place(self.inner.as_ptr());
+            // and then we still have to free the memory
+            dealloc(self.inner.as_ptr() as *mut u8, layout)
+        }
+    }
+}
+
+impl<T: ?Sized + PartialEq> PartialEq for Interned<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner().value.eq(&other.inner().value)
+    }
+}
+impl<T: ?Sized + Eq> Eq for Interned<T> {}
+
+impl<T: ?Sized + PartialOrd> PartialOrd for Interned<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.inner().value.partial_cmp(&other.inner().value)
+    }
+}
+impl<T: ?Sized + Ord> Ord for Interned<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.inner().value.cmp(&other.inner().value)
+    }
+}
+
+impl<T: ?Sized + Hash> Hash for Interned<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.inner().value.hash(state)
+    }
+}
+
+impl<T: ?Sized> Borrow<T> for Interned<T> {
+    fn borrow(&self) -> &T {
+        &self.inner().value
+    }
+}
+
+// The following would be nice, but it clashes with the Borrow<T> for T blanket impl
+// impl<T: ?Sized + Borrow<X>, X: ?Sized> Borrow<X> for Interned<T> {
+//     fn borrow(&self) -> &T {
+//         &self.inner().value.borrow()
+//     }
+// }
+
+impl<T: ?Sized> Deref for Interned<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.borrow()
+    }
+}
+
+impl<T: ?Sized + Debug> Debug for Interned<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "Interned({:?})", &*self)
+    }
+}

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -41,13 +41,14 @@ struct Inner<T: ?Sized> {
 unsafe impl<T: ?Sized + Sync + Send> Send for Inner<T> {}
 unsafe impl<T: ?Sized + Sync + Send> Sync for Inner<T> {}
 
-fn remover<T: ?Sized + Ord>(this: *const (), key: &Interned<T>) {
+fn remover<T: ?Sized + Ord>(this: *const (), key: *const Interned<T>) {
     // this is safe because we’re still holding a weak reference: the value may be dropped
     // but the ArcInner is still alive!
     let weak = unsafe { Weak::from_raw(this as *const Inner<T>) };
     if let Some(strong) = weak.upgrade() {
         let mut map = strong.map.lock();
-        let _value = map.take(key);
+        // Please see Interned::drop() for an explanation why `key` is safe in this case
+        let _value = map.take(unsafe { &*key });
         // drop the lock before dropping the value, in case the value has Drop glue that needs
         // this lock
         drop(map);

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -95,6 +95,31 @@ where
     InternedTree(ret)
 }
 
+/// Intern an owned value using tree map (will not clone)
+pub fn intern_tree<T>(val: T) -> InternedTree<T>
+where
+    T: Ord + Send + Sync + 'static,
+{
+    intern_tree_arc(Arc::new(val))
+}
+
+/// Intern a non-owned reference using tree map (will clone)
+pub fn intern_tree_unsized<T>(val: &T) -> InternedTree<T>
+where
+    T: Ord + Send + Sync + ?Sized + 'static,
+    Arc<T>: for<'a> From<&'a T>,
+{
+    intern_tree_arc(Arc::from(val))
+}
+
+/// Intern an owned reference using tree map (will not clone)
+pub fn intern_tree_boxed<T>(val: Box<T>) -> InternedTree<T>
+where
+    T: Ord + Send + Sync + ?Sized + 'static,
+{
+    intern_tree_arc(Arc::from(val))
+}
+
 /// Perform internal maintenance (removing otherwise unreferenced elements) and return count of elements
 pub fn num_objects_interned_tree<T: Ord + ?Sized + 'static>() -> usize {
     if let Some(m) = CONTAINER_TREE

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Actyx AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 use crate::ref_count::{Interned, RemovalResult, RemovePtr};
 use parking_lot::{Mutex, MutexGuard};
 use std::{

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,0 +1,128 @@
+use dashmap::DashMap;
+use std::{
+    any::TypeId,
+    collections::{btree_map::Entry, BTreeMap},
+    fmt::Display,
+    ops::Deref,
+    sync::{Arc, Mutex},
+};
+
+use crate::CONTAINER_TREE;
+
+struct TreeContainer<T: ?Sized> {
+    tree: Mutex<BTreeMap<Arc<T>, ()>>,
+}
+
+impl<T: Ord + ?Sized> TreeContainer<T> {
+    pub fn new() -> Self {
+        TreeContainer {
+            tree: Mutex::new(BTreeMap::new()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct InternedTree<T: ?Sized + Ord + 'static>(Arc<T>);
+
+impl<T: ?Sized + Ord + 'static> InternedTree<T> {
+    pub fn references(this: &Self) -> usize {
+        Arc::strong_count(&this.0)
+    }
+}
+
+impl<T: ?Sized + Ord + 'static + Display> Display for InternedTree<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<T: ?Sized + Ord + 'static> Deref for InternedTree<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl<T: ?Sized + Ord + 'static> Drop for InternedTree<T> {
+    fn drop(&mut self) {
+        if Arc::strong_count(&self.0) == 2 {
+            if let Some(boxed) = CONTAINER_TREE
+                .get_or_init(DashMap::new)
+                .get(&TypeId::of::<T>())
+            {
+                let m = boxed.value().downcast_ref::<TreeContainer<T>>().unwrap();
+                let mut set = m.tree.lock().unwrap();
+                if Arc::strong_count(&self.0) == 2 {
+                    set.remove(&self.0);
+                }
+            }
+        }
+    }
+}
+
+/// Intern a shared-ownership reference using tree map (will not clone)
+///
+/// Returns either the given Arc or an already-interned one pointing to an equivalent value.
+pub fn intern_tree_arc<T>(val: Arc<T>) -> InternedTree<T>
+where
+    T: Ord + Send + Sync + ?Sized + 'static,
+{
+    let type_map = CONTAINER_TREE.get_or_init(DashMap::new);
+
+    // Prefer taking the read lock to reduce contention, only use entry api if necessary.
+    let boxed = if let Some(boxed) = type_map.get(&TypeId::of::<T>()) {
+        boxed
+    } else {
+        type_map
+            .entry(TypeId::of::<T>())
+            .or_insert_with(|| Box::new(TreeContainer::<T>::new()))
+            .downgrade()
+    };
+
+    let m: &TreeContainer<T> = boxed.value().downcast_ref::<TreeContainer<T>>().unwrap();
+    let mut set = m.tree.lock().unwrap();
+    let ret = match set.entry(val) {
+        Entry::Vacant(x) => {
+            let ret = x.key().clone();
+            x.insert(());
+            ret
+        }
+        Entry::Occupied(x) => x.key().clone(),
+    };
+
+    InternedTree(ret)
+}
+
+/// Perform internal maintenance (removing otherwise unreferenced elements) and return count of elements
+pub fn num_objects_interned_tree<T: Ord + ?Sized + 'static>() -> usize {
+    if let Some(m) = CONTAINER_TREE
+        .get()
+        .and_then(|type_map| type_map.get(&TypeId::of::<T>()))
+    {
+        let m = m.downcast_ref::<TreeContainer<T>>().unwrap();
+        let s = m.tree.lock().unwrap();
+        s.len()
+    } else {
+        0
+    }
+}
+
+/// Feed an iterator over all interned values for the given type to the given function
+pub fn inspect_tree<T, F, U>(f: F) -> U
+where
+    T: Ord + ?Sized + 'static,
+    F: for<'a> FnOnce(Box<dyn Iterator<Item = Arc<T>> + 'a>) -> U,
+{
+    let o = CONTAINER_TREE
+        .get()
+        .and_then(|type_map| type_map.get(&TypeId::of::<T>()));
+    if let Some(r) = o {
+        let m = r.downcast_ref::<TreeContainer<T>>().unwrap();
+        let map = m.tree.lock().unwrap();
+        f(Box::new(map.iter().map(|(k, _v)| k.clone())))
+    } else {
+        f(Box::new(std::iter::empty()))
+    }
+}

--- a/tests/smoke_and_miri.rs
+++ b/tests/smoke_and_miri.rs
@@ -1,0 +1,243 @@
+use intern_arc::*;
+use std::thread;
+
+// Test basic functionality.
+#[test]
+fn basic_hash() {
+    let interner = InternHash::<&str>::new();
+
+    assert_eq!(interner.intern_sized("foo"), interner.intern_sized("foo"));
+    assert_ne!(interner.intern_sized("foo"), interner.intern_sized("bar"));
+    // The above refs should be deallocated by now.
+    assert_eq!(interner.len(), 0);
+
+    let interner = InternHash::<String>::new();
+
+    let interned1 = interner.intern_sized("foo".to_string());
+    {
+        let interned2 = interner.intern_sized("foo".to_string());
+        let interned3 = interner.intern_sized("bar".to_string());
+
+        assert_eq!(interned2.ref_count(), 3);
+        assert_eq!(interned3.ref_count(), 2);
+        // We now have two unique interned strings: "foo" and "bar".
+        assert_eq!(interner.len(), 2);
+    }
+
+    // "bar" is now gone.
+    assert_eq!(interner.len(), 1);
+
+    drop(interner);
+    assert_eq!(interned1.ref_count(), 1);
+}
+
+// Test basic functionality.
+#[test]
+fn basic_hash_unsized() {
+    let interner = InternHash::<str>::new();
+
+    assert_eq!(interner.intern_ref("foo"), interner.intern_ref("foo"));
+    assert_ne!(interner.intern_ref("foo"), interner.intern_ref("bar"));
+    // The above refs should be deallocated by now.
+    assert_eq!(interner.len(), 0);
+
+    let interned1 = interner.intern_ref("foo");
+    {
+        let interned2 = interner.intern_ref("foo");
+        let interned3 = interner.intern_ref("bar");
+
+        assert_eq!(interned2.ref_count(), 3);
+        assert_eq!(interned3.ref_count(), 2);
+        // We now have two unique interned strings: "foo" and "bar".
+        assert_eq!(interner.len(), 2);
+    }
+
+    // "bar" is now gone.
+    assert_eq!(interner.len(), 1);
+
+    assert_eq!(
+        &*interned1 as *const _,
+        &*interner.intern_ref("foo") as *const _
+    );
+
+    drop(interner);
+
+    assert_ne!(
+        &*interned1 as *const _,
+        &*InternHash::new().intern_ref("foo") as *const _
+    );
+
+    assert_eq!(interned1.ref_count(), 1);
+}
+
+// Test basic functionality.
+#[test]
+fn basic_ord() {
+    let interner = InternOrd::<&str>::new();
+
+    assert_eq!(interner.intern_sized("foo"), interner.intern_sized("foo"));
+    assert_ne!(interner.intern_sized("foo"), interner.intern_sized("bar"));
+    // The above refs should be deallocated by now.
+    assert_eq!(interner.len(), 0);
+
+    let interner = InternOrd::<String>::new();
+
+    let interned1 = interner.intern_sized("foo".to_string());
+    {
+        let interned2 = interner.intern_sized("foo".to_string());
+        let interned3 = interner.intern_sized("bar".to_string());
+
+        assert_eq!(interned2.ref_count(), 3);
+        assert_eq!(interned3.ref_count(), 2);
+        // We now have two unique interned strings: "foo" and "bar".
+        assert_eq!(interner.len(), 2);
+    }
+
+    // "bar" is now gone.
+    assert_eq!(interner.len(), 1);
+
+    drop(interner);
+    assert_eq!(interned1.ref_count(), 1);
+}
+
+// Test basic functionality.
+#[test]
+fn basic_ord_unsized() {
+    let interner = InternOrd::<str>::new();
+
+    assert_eq!(interner.intern_ref("foo"), interner.intern_ref("foo"));
+    assert_ne!(interner.intern_ref("foo"), interner.intern_ref("bar"));
+    // The above refs should be deallocated by now.
+    assert_eq!(interner.len(), 0);
+
+    let interned1 = interner.intern_ref("foo");
+    {
+        let interned2 = interner.intern_ref("foo");
+        let interned3 = interner.intern_ref("bar");
+
+        assert_eq!(interned2.ref_count(), 3);
+        assert_eq!(interned3.ref_count(), 2);
+        // We now have two unique interned strings: "foo" and "bar".
+        assert_eq!(interner.len(), 2);
+    }
+
+    // "bar" is now gone.
+    assert_eq!(interner.len(), 1);
+
+    assert_eq!(
+        &*interned1 as *const _,
+        &*interner.intern_ref("foo") as *const _
+    );
+
+    drop(interner);
+
+    assert_ne!(
+        &*interned1 as *const _,
+        &*InternOrd::new().intern_ref("foo") as *const _
+    );
+
+    assert_eq!(interned1.ref_count(), 1);
+}
+
+// Ordering should be based on values, not pointers.
+// Also tests `Display` implementation.
+#[test]
+fn sorting() {
+    let interner = InternHash::new();
+    let mut interned_vals = vec![
+        interner.intern_sized(4),
+        interner.intern_sized(2),
+        interner.intern_sized(5),
+        interner.intern_sized(0),
+        interner.intern_sized(1),
+        interner.intern_sized(3),
+    ];
+    interned_vals.sort();
+    let sorted: Vec<String> = interned_vals.iter().map(|v| format!("{}", v)).collect();
+    assert_eq!(&sorted.join(","), "0,1,2,3,4,5");
+}
+
+#[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct TestStruct(String, u64);
+
+#[test]
+fn sequential_hash() {
+    let interner = InternHash::new();
+
+    for _i in 0..10 {
+        let mut interned = Vec::with_capacity(100);
+        for j in 0..10 {
+            interned.push(interner.intern_sized(TestStruct("foo".to_string(), j)));
+        }
+    }
+
+    assert_eq!(interner.len(), 0);
+}
+
+#[test]
+fn sequential_ord() {
+    let interner = InternOrd::new();
+
+    for _i in 0..10 {
+        let mut interned = Vec::with_capacity(100);
+        for j in 0..10 {
+            interned.push(interner.intern_sized(TestStruct("foo".to_string(), j)));
+        }
+    }
+
+    assert_eq!(interner.len(), 0);
+}
+
+// Quickly create and destroy a small number of interned objects from
+// multiple threads.
+#[test]
+fn multithreading_hash() {
+    let interner = InternHash::new();
+
+    let mut thandles = vec![];
+    for _i in 0..3 {
+        let interner = interner.clone();
+        thandles.push(thread::spawn(move || {
+            #[cfg(feature = "println")]
+            println!("begin");
+            #[allow(unused_variables)]
+            for i in 0..10 {
+                let _interned1 = interner.intern_sized(TestStruct("foo".to_string(), 5));
+                let _interned2 = interner.intern_sized(TestStruct("bar".to_string(), 10));
+                #[cfg(feature = "println")]
+                println!("loop {} done", i);
+            }
+        }));
+    }
+    for h in thandles.into_iter() {
+        h.join().unwrap()
+    }
+
+    assert_eq!(interner.len(), 0);
+}
+
+// Quickly create and destroy a small number of interned objects from
+// multiple threads.
+#[test]
+fn multithreading_ord() {
+    let interner = InternOrd::new();
+
+    let mut thandles = vec![];
+    for _i in 0..3 {
+        let interner = interner.clone();
+        thandles.push(thread::spawn(move || {
+            #[allow(unused_variables)]
+            for i in 0..10 {
+                let _interned1 = interner.intern_sized(TestStruct("foo".to_string(), 5));
+                let _interned2 = interner.intern_sized(TestStruct("bar".to_string(), 10));
+                #[cfg(feature = "println")]
+                println!("loop {} done", i);
+            }
+        }));
+    }
+    for h in thandles.into_iter() {
+        h.join().unwrap()
+    }
+
+    assert_eq!(interner.len(), 0);
+}

--- a/tests/smoke_and_miri.rs
+++ b/tests/smoke_and_miri.rs
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Actyx AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 use intern_arc::*;
 use std::thread;
 


### PR DESCRIPTION
- no more TypeId, explicitly managed interners per type
- immediately drop values without external references
- extensive benchmarking